### PR TITLE
修改 py 檔案開頭的直譯器宣告

### DIFF
--- a/line_notify_core.py
+++ b/line_notify_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 # In[ ]:

--- a/message.py
+++ b/message.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 # In[2]:


### PR DESCRIPTION
只寫 `python` 會變成 Python 2，要寫 `#!/usr/bin/env python3` 才會用 3 版執行。